### PR TITLE
feat: add --help and --version flags to cli

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40,11 +40,45 @@ function loadAliases() {
     }
     return {};
 }
+function showHelp() {
+    console.log(`
+Usage: pm [command] [args]
+
+Commands:
+  i, install        Install dependencies
+  <alias>           Runs the command mapped in alias.json
+  <script>          Runs the package.json script
+
+Options:
+  -h, --help        Show this help message
+  -v, --version     Show CLI version
+`);
+}
+function showVersion() {
+    const pkgJsonPath = join(__dirname, "..", "package.json");
+    if (existsSync(pkgJsonPath)) {
+        try {
+            const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+            console.log(`V${pkg.version ?? "unknown"}`);
+        }
+        catch {
+            console.log("Vunknown");
+        }
+    }
+}
 function run() {
     const cwd = process.cwd();
     const pm = detectPackageManager(cwd);
     const aliases = loadAliases();
     const args = process.argv.slice(2);
+    if (args[0] === "--help" || args[0] === "-h") {
+        showHelp();
+        process.exit(0);
+    }
+    if (args[0] === "--version" || args[0] === "-v") {
+        showVersion();
+        process.exit(0);
+    }
     if (args.length === 0) {
         console.log(`Package Manager: ${pm}`);
         console.table(aliases);

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,12 +39,49 @@ function loadAliases(): Record<string, string> {
   return {};
 }
 
+function showHelp() {
+  console.log(`
+Usage: pm [command] [args]
+
+Commands:
+  i, install        Install dependencies
+  <alias>           Runs the command mapped in alias.json
+  <script>          Runs the package.json script
+
+Options:
+  -h, --help        Show this help message
+  -v, --version     Show CLI version
+`);
+}
+
+function showVersion() {
+  const pkgJsonPath = join(__dirname, "..", "package.json");
+  if (existsSync(pkgJsonPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+      console.log(`V${pkg.version ?? "unknown"}`);
+    } catch {
+      console.log("Vunknown");
+    }
+  }
+}
+
 function run() {
   const cwd = process.cwd();
   const pm = detectPackageManager(cwd);
   const aliases = loadAliases();
 
   const args = process.argv.slice(2);
+  if (args[0] === "--help" || args[0] === "-h") {
+    showHelp();
+    process.exit(0);
+  }
+
+  if (args[0] === "--version" || args[0] === "-v") {
+    showVersion();
+    process.exit(0);
+  }
+
   if (args.length === 0) {
     console.log(`Package Manager: ${pm}`);
     console.table(aliases);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line flags for quick access to help (-h/--help) and version (-v/--version).
  * Display a concise usage banner with available commands and options when help is requested.
  * Prints the current version in a simple “V<version>” format.
  * Immediate responses for help/version requests without running other tasks.
* **Refactor**
  * Improved argument pre-processing to handle help and version before normal execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->